### PR TITLE
`Hook::bind_async` and `async` support in the `bind!` macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,6 +147,7 @@ dependencies = [
  "itoa",
  "kobold_macros",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-sys",
 ]
 

--- a/crates/kobold/Cargo.toml
+++ b/crates/kobold/Cargo.toml
@@ -17,6 +17,7 @@ stateful = []
 
 [dependencies]
 wasm-bindgen = "0.2.84"
+wasm-bindgen-futures = "0.4.34"
 itoa = "1.0.6"
 kobold_macros = { version = "0.7.0", path = "../kobold_macros" }
 console_error_panic_hook = "0.1.7"

--- a/crates/kobold/src/lib.rs
+++ b/crates/kobold/src/lib.rs
@@ -553,9 +553,15 @@ macro_rules! class {
 /// ```
 #[macro_export]
 macro_rules! bind {
-    ($hook:ident: $(let $v:ident = move |$e:tt $(: $e_ty:ty)?| $body:expr;)+) => {
+    ($hook:ident: $(let $v:ident = $async_move:tt |$e:tt $(: $e_ty:ty)?| $body:expr;)+) => {
         $(
-            let $v = $hook.bind(move |$hook, $e $(: $e_ty)*| $body);
+            let $v = $crate::bind!(@$async_move($hook, $e $(: $e_ty)*) $body);
         )*
+    };
+    (@move ($hook:ident, $e:tt $(: $e_ty:ty)*) $body:expr) => {
+        $hook.bind(move |$hook, $e $(: $e_ty)*| $body)
+    };
+    (@async ($hook:ident, $e:tt $(: $e_ty:ty)*) $body:expr) => {
+        $hook.bind_async(move |$hook, $e $(: $e_ty)*| async move { $body })
     };
 }


### PR DESCRIPTION
The CSV editor example showcases the new `async` support in the `bind!` macro:

https://github.com/maciejhirsz/kobold/blob/0a722429837224ff4bc1d95aa9dda40468c723f9/examples/csv_editor/src/main.rs#L12-L37

Will likely need to turn it into a proc macro soon for error handling unfortunately.