### PR TITLE
Restore `windows` feature for `crossterm`

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4.5.4", features = ["derive"] }
-crossterm = { version = "0.28.1", default-features = false }
+crossterm = { version = "0.28.1", default-features = false, features = ["windows"] }
 futures-lite = "2.5.0"
 http-body-util = "0.1.2"
 hyper = { version = "1.5.1", features = ["http1", "server"] }


### PR DESCRIPTION
`crossterm` crate requires enabling `windows` feature to be able to compile on Windows. As you can see [here](https://github.com/crossterm-rs/crossterm/blob/master/Cargo.toml#L63), an additional `[target.'cfg(windows)'.dependencies]` is not needed and this change will not affect non-Windows users