### PR TITLE
SVG QR codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,8 +343,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags 2.9.0",
+ "crossterm_winapi",
  "parking_lot",
  "rustix",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -499,9 +510,9 @@ dependencies = [
 
 [[package]]
 name = "fast_qr"
-version = "0.12.7"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e326670ab63ef13c7699301dbb3441573ba3288e83c3bb9efaacc91a33fd01"
+checksum = "1f5ea9788036fedaf55f43a2db0ba01eedf47d26fd6852f01e5cf51952571d57"
 
 [[package]]
 name = "fastrand"
@@ -2527,6 +2538,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2534,6 +2561,12 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/crates/kobold_macros/src/gener/element.rs
+++ b/crates/kobold_macros/src/gener/element.rs
@@ -149,9 +149,10 @@ impl IntoGenerator for HtmlElement {
                         }
                     }
                     AttributeType::Unknown => {
+                        let name = attribute_name(&name.label);
                         el.hoisted = true;
 
-                        let prop = (Literal::string(&name.label), ".into()").tokenize();
+                        let prop = (Literal::string(name), ".into()").tokenize();
                         let attr = Attr::new("&AttributeName");
 
                         gener.add_field(expr.stream).attr(var, attr, prop);

--- a/crates/kobold_macros/src/itertools.rs
+++ b/crates/kobold_macros/src/itertools.rs
@@ -32,7 +32,7 @@ where
 }
 
 pub trait IteratorExt: Iterator + Sized {
-    fn join(self, sep: &str) -> Join<Self> {
+    fn join(self, sep: &str) -> Join<'_, Self> {
         Join {
             iter: UnsafeCell::new(self),
             sep,

--- a/crates/kobold_qr/Cargo.toml
+++ b/crates/kobold_qr/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["web", "wasm", "javascript", "qr"]
 description = "QR code component for Kobold"
 
 [dependencies]
-fast_qr = { version = "0.12.7" }
+fast_qr = { version = "0.13.1" }
 kobold = { version = "0.10.0", path = "../kobold" }
 wasm-bindgen.workspace = true
 

--- a/crates/kobold_qr/src/lib.rs
+++ b/crates/kobold_qr/src/lib.rs
@@ -1,13 +1,12 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
+use std::fmt::Write;
 
 use kobold::prelude::*;
-use wasm_bindgen::prelude::*;
 
 use fast_qr::qr::QRBuilder;
 use kobold::diff::fence;
-use web_sys::CanvasRenderingContext2d;
 
 /// Error Correction Coding has 4 levels
 pub enum Ecl {
@@ -45,41 +44,48 @@ impl Default for Ecl {
 pub fn qr(data: &str, size: usize, ecl: Ecl) -> impl View {
     fence(data, move || {
         let qr = QRBuilder::new(data).ecl(ecl.into()).build().ok()?;
-        let pixel = ((size / qr.size) + 1) * 2;
-        let pixels = qr.size * pixel;
+
+        let viewbox = format!("0 0 {} {}", qr.size, qr.size);
         let style = format!("width: {size}px; height: {size}px;");
+
+        // Most QR codes will generate a path with density of ~2.5 bytes per module,
+        // allocating 4 bytes per module should be more than sufficient.
+        let mut path = String::with_capacity(qr.data.len() * 4);
+
+        for (y, row) in qr.data.chunks_exact(qr.size).enumerate() {
+            let row = &mut row.iter();
+
+            // Find first filled module
+            let Some(x) = row.position(|m| m.value()) else {
+                continue;
+            };
+
+            // Move to the new line
+            let _ = write!(&mut path, "M{x} {y}");
+
+            loop {
+                // Draw a recangle for all continous modules
+                let width = row.take_while(|m| m.value()).count() + 1;
+
+                let _ = write!(&mut path, "v1h{width}v-1");
+
+                // Skip empty modules
+                let Some(empty) = row.position(|m| m.value()) else {
+                    break;
+                };
+
+                // Note: we are drawing a line here (`hN`) instead of moving (`mN 0`) to
+                //       save some bytes, this is fine as long as we don't render line stroke.
+                let _ = write!(&mut path, "h{}", empty + 1);
+            }
+        }
 
         Some(
             view! {
-                <canvas width={pixels} height={pixels} {style} />
+                <svg viewBox={viewbox} {style}>
+                    <path d={path} fill="currentColor">
+                </svg>
             }
-            .on_render(move |canvas| {
-                let ctx = match canvas.get_context("2d") {
-                    Ok(Some(ctx)) => ctx.unchecked_into::<CanvasRenderingContext2d>(),
-                    _ => return,
-                };
-
-                ctx.clear_rect(0., 0., pixels as f64, pixels as f64);
-
-                for (y, row) in qr.data.chunks(qr.size).take(qr.size).enumerate() {
-                    let mut row = row.iter().enumerate();
-
-                    while let Some((x, m)) = row.next() {
-                        if !m.value() {
-                            continue;
-                        }
-
-                        let w = 1 + (&mut row).take_while(|(_, m)| m.value()).count();
-
-                        ctx.fill_rect(
-                            (x * pixel) as f64,
-                            (y * pixel) as f64,
-                            (w * pixel) as f64,
-                            pixel as f64,
-                        )
-                    }
-                }
-            }),
         )
     })
 }

--- a/crates/kobold_qr/src/lib.rs
+++ b/crates/kobold_qr/src/lib.rs
@@ -3,9 +3,10 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 use std::fmt::Write;
 
-use kobold::prelude::*;
+use fast_qr::Module;
+use fast_qr::qr::QRBuilder;
 
-use fast_qr::{Module, qr::QRBuilder};
+use kobold::prelude::*;
 use kobold::diff::fence;
 
 /// Error Correction Coding has 4 levels

--- a/crates/kobold_qr/src/lib.rs
+++ b/crates/kobold_qr/src/lib.rs
@@ -5,7 +5,7 @@ use std::fmt::Write;
 
 use kobold::prelude::*;
 
-use fast_qr::qr::QRBuilder;
+use fast_qr::{Module, qr::QRBuilder};
 use kobold::diff::fence;
 
 /// Error Correction Coding has 4 levels
@@ -37,55 +37,74 @@ impl Default for Ecl {
     }
 }
 
+// QR code sizes are calculated as 17 + N * 4, where N is in range of (1, 40),
+// 33 is therefore a valid size, but 32 is not and we can use it to mark error.
+const ERROR_SIZE: usize = 32;
+const ERROR_PATH: &str = "M4 0L0 4L12 16L0 28L4 32L16 20L28 32L32 28L20 16L32 4L28 0L16 12L4 0z";
+
 #[component(
     size?: 200,
     ecl?,
 )]
 pub fn qr(data: &str, size: usize, ecl: Ecl) -> impl View {
     fence(data, move || {
-        let qr = QRBuilder::new(data).ecl(ecl.into()).build().ok()?;
+        let (data, qrsize) = match QRBuilder::new(data).ecl(ecl.into()).build() {
+            Ok(qr) => (qr.data, qr.size),
+            Err(_) => ([Module(0); _], ERROR_SIZE),
+        };
 
-        let viewbox = format!("0 0 {} {}", qr.size, qr.size);
+        let view_box = format!("0 0 {} {}", qrsize, qrsize);
         let style = format!("width: {size}px; height: {size}px;");
+        let d = draw_path(data, qrsize);
 
-        // Most QR codes will generate a path with density of ~2.5 bytes per module,
-        // allocating 4 bytes per module should be more than sufficient.
-        let mut path = String::with_capacity(qr.data.len() * 4);
+        view! {
+            <svg {view_box} {style}>
+                <path {d} fill="currentColor">
+            </svg>
+        }
+    })
+}
 
-        for (y, row) in qr.data.chunks_exact(qr.size).enumerate() {
-            let row = &mut row.iter();
+fn draw_path<const N: usize>(data: [Module; N], size: usize) -> String {
+    // Most QR codes will generate a path with density of ~2.5 bytes per module,
+    // allocating 4 bytes per module should be more than sufficient.
+    let mut buf = String::with_capacity(size * size * 4);
 
-            // Find first filled module
-            let Some(x) = row.position(|m| m.value()) else {
-                continue;
+    if size == ERROR_SIZE {
+        buf.push_str(ERROR_PATH);
+        return buf;
+    }
+
+    for (y, row) in data.chunks_exact(size).take(size).enumerate() {
+        let row = &mut row.iter();
+
+        // Find first filled module
+        let Some(x) = row.position(|m| m.value()) else {
+            continue;
+        };
+
+        // Move to the new line
+        let _ = write!(&mut buf, "M{x} {y}");
+
+        loop {
+            // Find all horizontally adjacent filled modules
+            let width = row.take_while(|m| m.value()).count() + 1;
+
+            // `v1`       : draw line 1 segment down
+            // `h{width}` : draw line {width} segments right
+            // `v-1`      : draw line 1 segment up
+            let _ = write!(&mut buf, "v1h{width}v-1");
+
+            // Skip empty modules
+            let Some(empty) = row.position(|m| m.value()) else {
+                break;
             };
 
-            // Move to the new line
-            let _ = write!(&mut path, "M{x} {y}");
-
-            loop {
-                // Draw a recangle for all continous modules
-                let width = row.take_while(|m| m.value()).count() + 1;
-
-                let _ = write!(&mut path, "v1h{width}v-1");
-
-                // Skip empty modules
-                let Some(empty) = row.position(|m| m.value()) else {
-                    break;
-                };
-
-                // Note: we are drawing a line here (`hN`) instead of moving (`mN 0`) to
-                //       save some bytes, this is fine as long as we don't render line stroke.
-                let _ = write!(&mut path, "h{}", empty + 1);
-            }
+            // Note: we are drawing a line here (`h{}`) instead of moving (`m{} 0`) to
+            //       save some bytes, this is fine as long as we don't render line stroke.
+            let _ = write!(&mut buf, "h{}", empty + 1);
         }
+    }
 
-        Some(
-            view! {
-                <svg viewBox={viewbox} {style}>
-                    <path d={path} fill="currentColor">
-                </svg>
-            }
-        )
-    })
+    buf
 }

--- a/crates/kobold_qr/src/lib.rs
+++ b/crates/kobold_qr/src/lib.rs
@@ -38,10 +38,10 @@ impl Default for Ecl {
     }
 }
 
-// QR code sizes are calculated as 17 + N * 4, where N is in range of (1, 40),
-// 33 is therefore a valid size, but 32 is not and we can use it to mark error.
-const ERROR_SIZE: usize = 32;
-const ERROR_PATH: &str = "M4 0L0 4L12 16L0 28L4 32L16 20L28 32L32 28L20 16L32 4L28 0L16 12L4 0z";
+// QR code sizes are calculated as 17 + N * 4, where N is in range of (1, 40).
+// 8 is therefore a valid size we can use to render the error image.
+const ERROR_SIZE: usize = 8;
+const ERROR_PATH: &str = "M1 0.5L7 6.5M7 0.5L1 6.5";
 
 #[component(
     size?: 200,
@@ -54,22 +54,23 @@ pub fn qr(data: &str, size: usize, ecl: Ecl) -> impl View {
             Err(_) => ([Module(0); _], ERROR_SIZE),
         };
 
-        let view_box = format!("0 0 {} {}", qrsize, qrsize);
+        // viewBox needs to be offset by 0.5 since lines are 1 unit wide drawn at the middle
+        let view_box = format!("0 -0.5 {} {}", qrsize, qrsize);
         let style = format!("width: {size}px; height: {size}px;");
         let d = draw_path(data, qrsize);
 
         view! {
             <svg {view_box} {style}>
-                <path {d} fill="currentColor">
+                <path {d} stroke="currentColor" stroke-width="1">
             </svg>
         }
     })
 }
 
 fn draw_path<const N: usize>(data: [Module; N], size: usize) -> String {
-    // Most QR codes will generate a path with density of ~2.5 bytes per module,
-    // allocating 4 bytes per module should be more than sufficient.
-    let mut buf = String::with_capacity(size * size * 4);
+    // Most QR codes will generate a path with density of ~1.5 bytes per module,
+    // pre-allocating 2 bytes per module should be more than sufficient.
+    let mut buf = String::with_capacity(size * size * 2);
 
     if size == ERROR_SIZE {
         buf.push_str(ERROR_PATH);
@@ -91,19 +92,15 @@ fn draw_path<const N: usize>(data: [Module; N], size: usize) -> String {
             // Find all horizontally adjacent filled modules
             let width = row.take_while(|m| m.value()).count() + 1;
 
-            // `v1`       : draw line 1 segment down
-            // `h{width}` : draw line {width} segments right
-            // `v-1`      : draw line 1 segment up
-            let _ = write!(&mut buf, "v1h{width}v-1");
+            // Draw a line of appropriate width
+            let _ = write!(&mut buf, "h{width}");
 
             // Skip empty modules
             let Some(empty) = row.position(|m| m.value()) else {
                 break;
             };
 
-            // Note: we are drawing a line here (`h{}`) instead of moving (`m{} 0`) to
-            //       save some bytes, this is fine as long as we don't render line stroke.
-            let _ = write!(&mut buf, "h{}", empty + 1);
+            let _ = write!(&mut buf, "m{} 0", empty + 1);
         }
     }
 


### PR DESCRIPTION
This changes behavior of the `qr` component from the `kobold_qr` crate to render the QR as an embedded `<svg>` element with a single `<path>`. This makes rendering on our end much easier than using canvas as only a single string (two if `viewBox` changes) needs updating on data change.

Each row of modules is rendered as lines with a stroke width of 1 unit, the viewBox is adjusted to make sure the lines match the size of the image. This method is extremely efficient, merging horizontally adjacent modules produces path strings of ~1.5 bytes per QR code module.