### PR TITLE
Functional event delegation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "kobold_qr"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "fast_qr",
  "kobold",

--- a/crates/kobold/js/util.js
+++ b/crates/kobold/js/util.js
@@ -42,12 +42,19 @@ export function delegateEvent(i) {
 	document.body.addEventListener(event, e => {
 		let probe = e.target;
 
-		while !Object.hasOwn(probe, symbol) {
+		while (!Object.hasOwn(probe, symbol)) {
 			probe = probe.parentElement;
 
 			if (probe == null) {
 				return;
 			}
+		}
+
+		e.__delegateTarget = probe;
+
+		if (probe[symbol] === 0) {
+			history.pushState(null,'', probe.href);
+			e.preventDefault();
 		}
 
 		wasmBindings.koboldTrigger(probe[symbol], e);
@@ -88,6 +95,5 @@ export function removeClass(n,v) { n.classList.remove(v); }
 export function replaceClass(n,o,v) { n.classList.replace(o,v); }
 export function toggleClass(n,c,v) { n.classList.toggle(c,v); }
 
-export function popState() { window.onpopstate = makeEventHandler(0); }
-export function pushState(e) { e.preventDefault(); history.pushState(null,'',e.currentTarget.href); }
+export function popState() { window.onpopstate = (e) => wasmBindings.koboldTrigger(0, e); }
 export function getPath() { return document.location.pathname; }

--- a/crates/kobold/js/util.js
+++ b/crates/kobold/js/util.js
@@ -88,7 +88,6 @@ export function removeClass(n,v) { n.classList.remove(v); }
 export function replaceClass(n,o,v) { n.classList.replace(o,v); }
 export function toggleClass(n,c,v) { n.classList.toggle(c,v); }
 
-export function makeEventHandler(eid) { return (e) => wasmBindings.koboldTrigger(eid,e); }
 export function popState() { window.onpopstate = makeEventHandler(0); }
 export function pushState(e) { e.preventDefault(); history.pushState(null,'',e.currentTarget.href); }
 export function getPath() { return document.location.pathname; }

--- a/crates/kobold/js/util.js
+++ b/crates/kobold/js/util.js
@@ -1,10 +1,57 @@
-const fragmentDecorators = new WeakMap();
+// Must be kept in sync with runtime::events
+const events = [
+	"click",
+	"dblclick",
+	"pointerdown",
+	"pointerup",
+	"pointermove",
+	"pointerover",
+	"pointerout",
+	"pointercancel",
+	"contextmenu",
+	"wheel",
+	"touchstart",
+	"touchmove",
+	"touchend",
+	"touchcancel",
+	"keydown",
+	"keyup",
+	"focusin",
+	"focusout",
+	"change",
+	"reset",
+	"invalid",
+	"beforeinput",
+	"select",
+];
+
+const eventSymbols = window.$_koboldSym = Array(23);
+
+const fragmentDecorators = Symbol();
 
 export function appendBody(n) {
 	document.body.appendChild(n);
 }
 export function createTextNode(t) {
 	return document.createTextNode(t);
+}
+export function delegateEvent(i) {
+	let event = events[i];
+	let symbol = eventSymbols[i] = Symbol(event);
+
+	document.body.addEventListener(event, e => {
+		let probe = e.target;
+
+		while !Object.hasOwn(probe, symbol) {
+			probe = probe.parentElement;
+
+			if (probe == null) {
+				return;
+			}
+		}
+
+		wasmBindings.koboldTrigger(probe[symbol], e);
+	});
 }
 
 export function emptyNode() { return document.createTextNode(""); }
@@ -15,19 +62,19 @@ export function fragment()
 	return f;
 };
 export function fragmentDecorate(f) {
-	fragmentDecorators.set(f, [f.firstChild, f.lastChild]);
+	f[fragmentDecorators] = [f.firstChild, f.lastChild];
 	return f.lastChild;
 }
 export function fragmentUnmount(f)
 {
-	let [b, e] = fragmentDecorators.get(f);
+	let [b, e] = f[fragmentDecorators];
 	while (b.nextSibling !== e) f.appendChild(b.nextSibling);
 	f.appendChild(e);
 	f.insertBefore(b, f.firstChild);
 }
 export function fragmentReplace(f,n)
 {
-	let [b, e] = fragmentDecorators.get(f);
+	let [b, e] = f[fragmentDecorators];
 	while (b.nextSibling !== e) f.appendChild(b.nextSibling);
 	b.replaceWith(n);
 	f.appendChild(e);

--- a/crates/kobold/src/branching.rs
+++ b/crates/kobold/src/branching.rs
@@ -100,7 +100,7 @@ use web_sys::Node;
 
 use crate::dom::Anchor;
 use crate::internal::empty_node;
-use crate::runtime::{EventContext, Then, Trigger};
+use crate::runtime::{EventContext, Then, Trigger, UsedEvents};
 use crate::{Mountable, View};
 
 macro_rules! branch {
@@ -149,6 +149,11 @@ macro_rules! branch {
                 $var: Mountable,
             )*
         {
+            const EVENTS: UsedEvents = UsedEvents::empty()
+            $(
+                .combine($var::EVENTS)
+            )*;
+
             type Js = Node;
 
             fn js(&self) -> &JsValue {
@@ -207,6 +212,8 @@ pub struct EmptyNode(Node);
 pub struct Empty;
 
 impl Anchor for EmptyNode {
+    const EVENTS: UsedEvents = UsedEvents::empty();
+
     type Js = Node;
     type Target = Node;
 

--- a/crates/kobold/src/diff.rs
+++ b/crates/kobold/src/diff.rs
@@ -11,7 +11,7 @@ use web_sys::Node;
 
 use crate::attribute::Attribute;
 use crate::dom::{Anchor, TextContent};
-use crate::runtime::{EventContext, Then, Trigger};
+use crate::runtime::{EventContext, Then, Trigger, UsedEvents};
 use crate::value::{IntoText, Value};
 use crate::{Mountable, View};
 
@@ -95,6 +95,8 @@ impl<D, P> Anchor for Fence<D, P>
 where
     P: Mountable,
 {
+    const EVENTS: UsedEvents = P::EVENTS;
+
     type Js = P::Js;
     type Target = P;
 

--- a/crates/kobold/src/dom.rs
+++ b/crates/kobold/src/dom.rs
@@ -10,10 +10,12 @@ use wasm_bindgen::{JsCast, JsValue};
 use web_sys::Node;
 
 use crate::internal;
-use crate::runtime::Trigger;
+use crate::runtime::{Trigger, UsedEvents};
 
 /// A type that can be mounted in the DOM
 pub trait Mountable: Trigger + 'static {
+    const EVENTS: UsedEvents;
+
     /// The concrete `web-sys` type representing the root of this
     /// product, most often [`HtmlElement`](web_sys::HtmlElement).
     type Js: JsCast;
@@ -31,6 +33,8 @@ pub trait Mountable: Trigger + 'static {
 /// A light-weight [`Deref`]-like trait that
 /// auto-implements `Mountable` by proxying it to another type.
 pub trait Anchor {
+    const EVENTS: UsedEvents;
+
     type Js: JsCast;
     type Target: Mountable;
 
@@ -42,6 +46,8 @@ where
     T: Anchor + Trigger + 'static,
     T::Target: Mountable,
 {
+    const EVENTS: UsedEvents = T::EVENTS;
+
     type Js = T::Js;
 
     fn js(&self) -> &JsValue {
@@ -132,6 +138,8 @@ impl Deref for FragmentBuilder {
 }
 
 impl Mountable for Node {
+    const EVENTS: UsedEvents = UsedEvents::empty();
+
     type Js = Node;
 
     fn js(&self) -> &JsValue {
@@ -148,6 +156,8 @@ impl Mountable for Node {
 }
 
 impl Mountable for Fragment {
+    const EVENTS: UsedEvents = UsedEvents::empty();
+
     type Js = Node;
 
     fn js(&self) -> &JsValue {

--- a/crates/kobold/src/event.rs
+++ b/crates/kobold/src/event.rs
@@ -20,7 +20,7 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     fn target(this: &EventWithTarget) -> HtmlElement;
 
-    #[wasm_bindgen(method, getter, js_name = "currentTarget")]
+    #[wasm_bindgen(method, getter, js_name = "__delegateTarget")]
     fn current_target(this: &EventWithTarget) -> HtmlElement;
 }
 
@@ -65,7 +65,7 @@ macro_rules! event {
                 where
                     T: JsCast,
                 {
-                    EventTarget(self.event.unchecked_ref::<EventWithTarget>().current_target().unchecked_into())
+                    EventTarget(self.event.unchecked_ref::<EventWithTarget>().target().unchecked_into())
                 }
             }
         )*

--- a/crates/kobold/src/event.rs
+++ b/crates/kobold/src/event.rs
@@ -8,10 +8,9 @@ use std::marker::PhantomData;
 use std::ops::Deref;
 
 use wasm_bindgen::prelude::wasm_bindgen;
-use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen::JsCast;
 use web_sys::{HtmlElement, HtmlInputElement};
 
-use crate::internal;
 use crate::runtime::{EventContext, EventId, Then, Trigger};
 
 #[wasm_bindgen]
@@ -141,7 +140,7 @@ pub struct ListenerProduct<F, E> {
 }
 
 pub trait ListenerHandle: Trigger {
-    fn js_value(&mut self) -> JsValue;
+    fn event_key(&mut self) -> u32;
 }
 
 impl<F, E> ListenerHandle for ListenerProduct<F, E>
@@ -149,8 +148,8 @@ where
     F: Fn(&E) + 'static,
     E: EventCast,
 {
-    fn js_value(&mut self) -> JsValue {
-        internal::make_event_handler(self.eid.0)
+    fn event_key(&mut self) -> u32 {
+        self.eid.0
     }
 }
 

--- a/crates/kobold/src/internal.rs
+++ b/crates/kobold/src/internal.rs
@@ -93,12 +93,6 @@ mod hidden {
     pub fn kobold_trigger(eid: u32, event: web_sys::Event) {
         trigger(EventId(eid), event);
     }
-
-    #[wasm_bindgen(js_name = "koboldLink")]
-    pub fn kobold_link(event: web_sys::Event) {
-        super::push_state(&event);
-        trigger(EventId(0), event);
-    }
 }
 
 #[wasm_bindgen(module = "/js/util.js")]
@@ -146,8 +140,6 @@ extern "C" {
 
     #[wasm_bindgen(js_name = "popState")]
     pub(crate) fn pop_state();
-    #[wasm_bindgen(js_name = "pushState")]
-    pub(crate) fn push_state(e: &JsValue);
     #[wasm_bindgen(js_name = "getPath")]
     pub(crate) fn get_path() -> String;
 }

--- a/crates/kobold/src/internal.rs
+++ b/crates/kobold/src/internal.rs
@@ -112,6 +112,9 @@ extern "C" {
     #[wasm_bindgen(js_name = createTextNode)]
     pub(crate) fn text_node_bool(t: bool) -> Node;
 
+    #[wasm_bindgen(js_name = "delegateEvent")]
+    pub(crate) fn delegate_event(kind: i32);
+
     #[wasm_bindgen(js_name = "emptyNode")]
     pub(crate) fn empty_node() -> Node;
     #[wasm_bindgen(js_name = "fragment")]

--- a/crates/kobold/src/internal.rs
+++ b/crates/kobold/src/internal.rs
@@ -144,8 +144,6 @@ extern "C" {
 
     // ----------------
 
-    #[wasm_bindgen(js_name = "makeEventHandler")]
-    pub(crate) fn make_event_handler(eid: u32) -> JsValue;
     #[wasm_bindgen(js_name = "popState")]
     pub(crate) fn pop_state();
     #[wasm_bindgen(js_name = "pushState")]

--- a/crates/kobold/src/list/bounded.rs
+++ b/crates/kobold/src/list/bounded.rs
@@ -8,7 +8,7 @@ use std::ops::{Deref, DerefMut};
 use web_sys::Node;
 
 use crate::dom::{Anchor, Fragment, FragmentBuilder};
-use crate::runtime::{EventContext, Then, Trigger};
+use crate::runtime::{EventContext, Then, Trigger, UsedEvents};
 use crate::{Mountable, View};
 
 pub struct BoundedProduct<P: Mountable, const N: usize> {
@@ -99,6 +99,8 @@ impl<P, const N: usize> Anchor for BoundedProduct<P, N>
 where
     P: Mountable,
 {
+    const EVENTS: UsedEvents = P::EVENTS;
+
     type Js = Node;
     type Target = Fragment;
 

--- a/crates/kobold/src/list/unbounded.rs
+++ b/crates/kobold/src/list/unbounded.rs
@@ -7,7 +7,7 @@
 use web_sys::Node;
 
 use crate::dom::{Anchor, Fragment, FragmentBuilder};
-use crate::runtime::{EventContext, Then, Trigger};
+use crate::runtime::{EventContext, Then, Trigger, UsedEvents};
 use crate::{Mountable, View};
 
 pub struct ListProduct<P: Mountable> {
@@ -98,6 +98,8 @@ impl<P> Anchor for ListProduct<P>
 where
     P: Mountable,
 {
+    const EVENTS: UsedEvents = P::EVENTS;
+
     type Js = Node;
     type Target = Fragment;
 

--- a/crates/kobold/src/path.rs
+++ b/crates/kobold/src/path.rs
@@ -4,8 +4,8 @@
 use wasm_bindgen::JsValue;
 
 use crate::internal::get_path;
-use crate::runtime::POPSTATE_EID;
 use crate::runtime::{EventContext, Then, Trigger};
+use crate::runtime::{POPSTATE_EID, UsedEvents};
 use crate::{Mountable, View};
 
 pub struct PopState<F> {
@@ -55,6 +55,8 @@ impl<P> Mountable for PopStateProduct<P>
 where
     P: Mountable,
 {
+    const EVENTS: UsedEvents = P::EVENTS;
+
     type Js = P::Js;
 
     fn js(&self) -> &JsValue {

--- a/crates/kobold/src/runtime.rs
+++ b/crates/kobold/src/runtime.rs
@@ -9,10 +9,12 @@ use web_sys::Event;
 use crate::{Mountable, View, internal};
 
 mod ctx;
+mod event;
 
 use ctx::EventCtx;
 
 pub use ctx::EventContext;
+pub use event::{EventKind, UsedEvents};
 
 /// 0 is reserved for popstate events so links can be triggered
 /// without having to pass any context.
@@ -99,6 +101,9 @@ where
     INIT.set(true);
 
     init_panic_hook();
+
+    // Hook up delegated event handlers for all event kinds used by the app
+    V::Product::EVENTS.delegate();
 
     let runtime = Box::new(RuntimeData {
         product: render().build(),

--- a/crates/kobold/src/runtime/event.rs
+++ b/crates/kobold/src/runtime/event.rs
@@ -1,0 +1,68 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+use crate::internal::delegate_event;
+
+macro_rules! declare {
+    ($($variant:ident,)*) => {
+        pub enum EventKind {
+            $( $variant, )*
+        }
+
+        impl EventKind {
+            const COUNT: u32 = 0 $(+ { let _ = EventKind::$variant; 1 })*;
+        }
+    }
+}
+
+// Must be kept in sync with util.js
+declare! {
+    Click,
+    DblClick,
+    PointerDown,
+    PointerUp,
+    PointerMove,
+    PointerOver,
+    PointerOut,
+    PointerCancel,
+    ContextMenu,
+    Wheel,
+    TouchStart,
+    TouchMove,
+    TouchEnd,
+    TouchCancel,
+    KeyDown,
+    KeyUp,
+    FocusIn,
+    FocusOut,
+    Change,
+    Reset,
+    Invalid,
+    BeforeInput,
+    Select,
+}
+
+pub struct UsedEvents(u32);
+
+impl UsedEvents {
+    pub const fn empty() -> Self {
+        UsedEvents(0)
+    }
+
+    pub const fn used(mut self, kind: EventKind) -> Self {
+        self.0 |= 1 << kind as u32;
+        self
+    }
+
+    pub const fn combine(self, other: Self) -> Self {
+        UsedEvents(self.0 | other.0)
+    }
+
+    pub(crate) fn delegate(self) {
+        for i in 0..EventKind::COUNT {
+            if self.0 & (1 << i) > 0 {
+                delegate_event(i as _);
+            }
+        }
+    }
+}

--- a/crates/kobold/src/runtime/event.rs
+++ b/crates/kobold/src/runtime/event.rs
@@ -59,6 +59,9 @@ impl UsedEvents {
     }
 
     pub(crate) fn delegate(self) {
+        delegate_event(0);
+        delegate_event(15);
+
         for i in 0..EventKind::COUNT {
             if self.0 & (1 << i) > 0 {
                 delegate_event(i as _);

--- a/crates/kobold/src/runtime/event.rs
+++ b/crates/kobold/src/runtime/event.rs
@@ -59,9 +59,6 @@ impl UsedEvents {
     }
 
     pub(crate) fn delegate(self) {
-        delegate_event(0);
-        delegate_event(15);
-
         for i in 0..EventKind::COUNT {
             if self.0 & (1 << i) > 0 {
                 delegate_event(i as _);

--- a/crates/kobold/src/state.rs
+++ b/crates/kobold/src/state.rs
@@ -13,7 +13,7 @@
 //!
 use wasm_bindgen::JsValue;
 
-use crate::runtime::{EventContext, Then, Trigger};
+use crate::runtime::{EventContext, Then, Trigger, UsedEvents};
 use crate::{Mountable, View};
 
 mod hook;
@@ -89,6 +89,8 @@ where
     S: 'static,
     P: Mountable,
 {
+    const EVENTS: UsedEvents = P::EVENTS;
+
     type Js = P::Js;
 
     fn js(&self) -> &JsValue {
@@ -146,6 +148,8 @@ where
     StatefulProduct<S, P>: Mountable,
     D: 'static,
 {
+    const EVENTS: UsedEvents = <StatefulProduct<S, P> as Mountable>::EVENTS;
+
     type Js = <StatefulProduct<S, P> as Mountable>::Js;
 
     fn js(&self) -> &JsValue {

--- a/crates/kobold/src/state/hook.rs
+++ b/crates/kobold/src/state/hook.rs
@@ -6,12 +6,11 @@ use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 use std::ptr::NonNull;
 
-use wasm_bindgen::JsValue;
 // use wasm_bindgen_futures::spawn_local;
 
+use crate::View;
 use crate::event::{EventCast, Listener, ListenerHandle};
 use crate::runtime::{EventContext, EventId, Then, Trigger};
-use crate::{View, internal};
 
 pub struct Signal<S> {
     // _sid: StateId,
@@ -193,8 +192,8 @@ where
     F: Fn(&mut S, &E) -> O + 'static,
     O: Into<Then>,
 {
-    fn js_value(&mut self) -> JsValue {
-        internal::make_event_handler(self.eid.0)
+    fn event_key(&mut self) -> u32 {
+        self.eid.0
     }
 }
 

--- a/crates/kobold/src/value.rs
+++ b/crates/kobold/src/value.rs
@@ -8,7 +8,7 @@ use crate::View;
 use crate::diff::{Diff, Ver};
 use crate::dom::{Anchor, Property, TextContent};
 use crate::internal;
-use crate::runtime::Trigger;
+use crate::runtime::{Trigger, UsedEvents};
 
 /// Value that can be set as a property on DOM node
 pub trait Value<P>: IntoText {
@@ -65,6 +65,8 @@ pub struct TextProduct<M> {
 }
 
 impl<M> Anchor for TextProduct<M> {
+    const EVENTS: UsedEvents = UsedEvents::empty();
+
     type Js = web_sys::Text;
     type Target = Node;
 

--- a/crates/kobold_macros/src/dom.rs
+++ b/crates/kobold_macros/src/dom.rs
@@ -6,7 +6,7 @@ use tokens::{Delimiter, Ident, Literal, Span, TokenStream, TokenTree};
 
 use crate::event::EventKind;
 use crate::parse::prelude::*;
-use crate::syntax::CssLabel;
+use crate::syntax::Label;
 use crate::tokenize::prelude::*;
 
 mod els;
@@ -73,13 +73,13 @@ pub enum CssValue {
 
 #[derive(Debug)]
 pub struct Attribute {
-    pub name: CssLabel,
+    pub name: Label,
     pub value: AttributeValue,
 }
 
 #[derive(Debug)]
 pub struct Event {
-    pub name: CssLabel,
+    pub name: Label,
     pub kind: EventKind,
     pub value: Expression,
 }
@@ -169,7 +169,7 @@ impl Node {
                     if content.allow_consume('.').is_some() {
                         classes.push(content.parse()?);
                     } else if let Some(hash) = content.allow_consume('#') {
-                        let name = CssLabel {
+                        let name = Label {
                             label: "id".into(),
                             ident: Ident::new("id", hash.span()),
                         };
@@ -187,9 +187,9 @@ impl Node {
                 while !content.end() {
                     let attr: Attribute = content.parse()?;
 
-                    if attr.name.label.starts_with("on") {
+                    if attr.name.starts_with("on") {
                         let span = attr.name.ident.span();
-                        let kind = EventKind::try_from(&attr.name.label[2..])
+                        let kind = EventKind::try_from(&attr.name[2..])
                             .map_err(|()| ParseError::new("Unknown event", span))?;
 
                         let value = match attr.value {
@@ -202,11 +202,11 @@ impl Node {
                             AttributeValue::Expression(expr) => expr,
                         };
 
-                        events.push(Event {
-                            name: attr.name,
-                            kind,
-                            value,
-                        })
+                        let mut name = attr.name;
+
+                        name.replace_range(..2, "");
+
+                        events.push(Event { name, kind, value });
                     } else if attr.name.label == "class" {
                         classes.push(CssValue::try_from(attr.value)?);
                     } else {
@@ -341,7 +341,7 @@ impl Parse for CssValue {
             return Ok(CssValue::Expression(Expression::try_from(expr)?));
         }
 
-        let css_label: CssLabel = stream
+        let css_label: Label = stream
             .parse()
             .map_err(|err| err.msg("Expected identifier or an {expression}"))?;
 

--- a/crates/kobold_macros/src/dom.rs
+++ b/crates/kobold_macros/src/dom.rs
@@ -4,6 +4,7 @@
 
 use tokens::{Delimiter, Ident, Literal, Span, TokenStream, TokenTree};
 
+use crate::event::EventKind;
 use crate::parse::prelude::*;
 use crate::syntax::CssLabel;
 use crate::tokenize::prelude::*;
@@ -53,6 +54,7 @@ pub struct HtmlElement {
     pub name: ElementTag,
     pub span: Span,
     pub classes: Vec<CssValue>,
+    pub events: Vec<Event>,
     pub attributes: Vec<Attribute>,
     pub children: Option<Vec<Node>>,
 }
@@ -73,6 +75,13 @@ pub enum CssValue {
 pub struct Attribute {
     pub name: CssLabel,
     pub value: AttributeValue,
+}
+
+#[derive(Debug)]
+pub struct Event {
+    pub name: CssLabel,
+    pub kind: EventKind,
+    pub value: Expression,
 }
 
 #[derive(Debug)]
@@ -153,6 +162,7 @@ impl Node {
             TagName::HtmlElement { name, span } => {
                 let mut content = tag.content.parse_stream();
                 let mut classes = Vec::new();
+                let mut events = Vec::new();
                 let mut attributes = Vec::new();
 
                 loop {
@@ -177,7 +187,27 @@ impl Node {
                 while !content.end() {
                     let attr: Attribute = content.parse()?;
 
-                    if attr.name.label == "class" {
+                    if attr.name.label.starts_with("on") {
+                        let span = attr.name.ident.span();
+                        let kind = EventKind::try_from(&attr.name.label[2..])
+                            .map_err(|()| ParseError::new("Unknown event", span))?;
+
+                        let value = match attr.value {
+                            AttributeValue::Literal(_) | AttributeValue::Boolean(_) => {
+                                return Err(ParseError::new(
+                                    "Event handler value must be an expression",
+                                    span,
+                                ));
+                            }
+                            AttributeValue::Expression(expr) => expr,
+                        };
+
+                        events.push(Event {
+                            name: attr.name,
+                            kind,
+                            value,
+                        })
+                    } else if attr.name.label == "class" {
                         classes.push(CssValue::try_from(attr.value)?);
                     } else {
                         attributes.push(attr);
@@ -193,6 +223,7 @@ impl Node {
                     name,
                     span,
                     classes,
+                    events,
                     attributes,
                     children,
                 }));

--- a/crates/kobold_macros/src/event.rs
+++ b/crates/kobold_macros/src/event.rs
@@ -1,0 +1,120 @@
+use std::fmt::{self, Debug};
+
+// Must be kept in sync with kobold::runtime::event
+#[derive(Clone, Copy)]
+pub enum EventKind {
+    Click,
+    DblClick,
+    PointerDown,
+    PointerUp,
+    PointerMove,
+    PointerOver,
+    PointerOut,
+    PointerCancel,
+    ContextMenu,
+    Wheel,
+    TouchStart,
+    TouchMove,
+    TouchEnd,
+    TouchCancel,
+    KeyDown,
+    KeyUp,
+    FocusIn,
+    FocusOut,
+    Change,
+    Reset,
+    Invalid,
+    BeforeInput,
+    Select,
+}
+
+impl Debug for EventKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_variant())
+    }
+}
+
+impl EventKind {
+    pub fn as_variant(&self) -> &str {
+        use EventKind::*;
+
+        match self {
+            Click => "Click",
+            DblClick => "DblClick",
+            PointerDown => "PointerDown",
+            PointerUp => "PointerUp",
+            PointerMove => "PointerMove",
+            PointerOver => "PointerOver",
+            PointerOut => "PointerOut",
+            PointerCancel => "PointerCancel",
+            ContextMenu => "ContextMenu",
+            Wheel => "Wheel",
+            TouchStart => "TouchStart",
+            TouchMove => "TouchMove",
+            TouchEnd => "TouchEnd",
+            TouchCancel => "TouchCancel",
+            KeyDown => "KeyDown",
+            KeyUp => "KeyUp",
+            FocusIn => "FocusIn",
+            FocusOut => "FocusOut",
+            Change => "Change",
+            Reset => "Reset",
+            Invalid => "Invalid",
+            BeforeInput => "BeforeInput",
+            Select => "Select",
+        }
+    }
+}
+
+impl TryFrom<&str> for EventKind {
+    type Error = ();
+
+    fn try_from(event: &str) -> Result<Self, Self::Error> {
+        use EventKind::*;
+
+        let kind = match event {
+            "click" => Click,
+            "dblclick" => DblClick,
+            "pointerdown" => PointerDown,
+            "pointerup" => PointerUp,
+            "pointermove" => PointerMove,
+            "poitnerover" => PointerOver,
+            "poitnerout" => PointerOut,
+            "pointercancel" => PointerCancel,
+            "contextmenu" => ContextMenu,
+            "wheel" => Wheel,
+            "touchstart" => TouchStart,
+            "touchmove" => TouchMove,
+            "touchend" => TouchEnd,
+            "touchcancel" => TouchCancel,
+            "keydown" => KeyDown,
+            "keyup" => KeyUp,
+            "focusin" => FocusIn,
+            "focusout" => FocusOut,
+            "change" => Change,
+            "reset" => Reset,
+            "invalid" => Invalid,
+            "beforeinput" => BeforeInput,
+            "select" => Select,
+
+            // aliases
+            "mousedown" => PointerDown,
+            "mouseup" => PointerUp,
+            "mousemove" => PointerMove,
+            "mouseenter" => PointerOver,
+            "mouseleave" => PointerOut,
+            "mouseover" => PointerOver,
+            "mouseout" => PointerOut,
+            "mousewheel" => Wheel,
+            "pointerenter" => PointerOver,
+            "pointerleave" => PointerOut,
+            "keypress" => KeyUp,
+            "focus" => FocusIn,
+            "blur" => FocusOut,
+
+            _ => return Err(()),
+        };
+
+        Ok(kind)
+    }
+}

--- a/crates/kobold_macros/src/event.rs
+++ b/crates/kobold_macros/src/event.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use std::fmt::{self, Debug};
 
 // Must be kept in sync with kobold::runtime::event

--- a/crates/kobold_macros/src/event.rs
+++ b/crates/kobold_macros/src/event.rs
@@ -5,7 +5,7 @@
 use std::fmt::{self, Debug};
 
 // Must be kept in sync with kobold::runtime::event
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum EventKind {
     Click,
     DblClick,

--- a/crates/kobold_macros/src/gener.rs
+++ b/crates/kobold_macros/src/gener.rs
@@ -9,6 +9,7 @@ use arrayvec::ArrayString;
 use tokens::{Ident, TokenStream};
 
 use crate::dom::{Expression, Node};
+use crate::event::EventKind;
 use crate::itertools::IteratorExt;
 use crate::tokenize::prelude::*;
 
@@ -57,6 +58,13 @@ impl Generator {
 
         self.out.fields.push(Field::new(name, value));
         self.out.fields.last_mut().unwrap()
+    }
+
+    fn add_used_event(&mut self, kind: EventKind) {
+        // A more robust de-duping here is likely an overkill
+        if !self.out.events.contains(&kind) {
+            self.out.events.push(kind);
+        }
     }
 
     fn add_hint(&mut self, name: Ident, typ: impl Tokenize) {

--- a/crates/kobold_macros/src/gener/element.rs
+++ b/crates/kobold_macros/src/gener/element.rs
@@ -6,7 +6,8 @@ use std::fmt::{Arguments, Write};
 
 use tokens::{Literal, TokenStream};
 
-use crate::dom::{Attribute, AttributeValue, CssValue, ElementTag, HtmlElement};
+use crate::dom::{Attribute, AttributeValue, CssValue, ElementTag, Event, HtmlElement};
+use crate::event::EventKind;
 use crate::gener::{DomNode, Generator, IntoGenerator, JsArgument, Short, append};
 use crate::itertools::IteratorExt as _;
 use crate::parse::IteratorExt as _;
@@ -93,18 +94,58 @@ impl IntoGenerator for HtmlElement {
             }
         }
 
+        for event in self.events {
+            let Event {
+                name,
+                kind,
+                mut value,
+            } = event;
+
+            let target = el.typ;
+            let event = event_js_type(&name);
+
+            let coerce = if is_inline_closure(&mut value.stream) {
+                call(
+                    format_args!(
+                        "::kobold::internal::fn_type_hint::<\
+                        ::kobold::event::{event}<\
+                            ::kobold::reexport::web_sys::{target}\
+                        >,\
+                        _,\
+                    >"
+                    ),
+                    value.stream,
+                )
+            } else {
+                value.stream
+            };
+
+            let value = gener.add_field(coerce).event(event, el.typ).name;
+
+            writeln!(el, "{var}[$_koboldSym[{}]]={value};", kind as usize);
+
+            el.args.push(JsArgument::with_abi(value, InlineAbi::Event));
+
+            gener.add_hint(
+                name.ident,
+                format_args!(
+                    "impl Fn(\
+                        &::kobold::event::{event}<\
+                            ::kobold::reexport::web_sys::{target}\
+                        >\
+                    ) + 'static"
+                ),
+            );
+        }
+
         for Attribute { name, value } in self.attributes {
-            let handler = attribute_handler(&name.label);
+            let handler = attribute_handler(&name);
 
             match value {
                 AttributeValue::Literal(value) => match handler {
-                    AttributeHandler::Event { name, .. } => {
-                        writeln!(el, "{var}.addEventListener(\"{name}\",{value});");
-                    }
                     AttributeHandler::Link => {
                         writeln!(el, "{var}.href={value};");
-                        writeln!(el, "{var}[$_koboldSym[0]]=0;")
-                        // writeln!(el, "{var}.onclick=e=>wasmBindings.koboldLink(e);")
+                        writeln!(el, "{var}[$_koboldSym[{}]]=0;", EventKind::Click as usize);
                     }
                     AttributeHandler::Prop { name, .. } => {
                         writeln!(el, "{var}.{name}={value};");
@@ -116,32 +157,7 @@ impl IntoGenerator for HtmlElement {
                 AttributeValue::Boolean(value) => {
                     writeln!(el, "{var}.{name}={value};");
                 }
-                AttributeValue::Expression(mut expr) => match &handler {
-                    AttributeHandler::Event { name, event } => {
-                        let target = el.typ;
-
-                        let coerce = if is_inline_closure(&mut expr.stream) {
-                            call(
-                                format_args!(
-                                    "::kobold::internal::fn_type_hint::<\
-                                    ::kobold::event::{event}<\
-                                        ::kobold::reexport::web_sys::{target}\
-                                    >,\
-                                    _,\
-                                >"
-                                ),
-                                expr.stream,
-                            )
-                        } else {
-                            expr.stream
-                        };
-
-                        let value = gener.add_field(coerce).event(event, el.typ).name;
-
-                        writeln!(el, "{var}.addEventListener(\"{name}\",{value});");
-
-                        el.args.push(JsArgument::with_abi(value, InlineAbi::Event))
-                    }
+                AttributeValue::Expression(expr) => match &handler {
                     AttributeHandler::Link => {
                         el.hoisted = true;
 
@@ -183,20 +199,6 @@ impl IntoGenerator for HtmlElement {
             };
 
             match handler {
-                AttributeHandler::Event { event, .. } => {
-                    let target = el.typ;
-
-                    gener.add_hint(
-                        name.ident,
-                        format_args!(
-                            "impl Fn(\
-                                &::kobold::event::{event}<\
-                                    ::kobold::reexport::web_sys::{target}\
-                                >\
-                            ) + 'static"
-                        ),
-                    );
-                }
                 AttributeHandler::Prop { attr, .. } => {
                     gener.add_attr_hint(name.ident, "", attr.hint);
                 }
@@ -230,7 +232,7 @@ impl InlineAbi {
         match self {
             InlineAbi::Bool => "bool",
             InlineAbi::Str => "&str",
-            InlineAbi::Event => "wasm_bindgen::JsValue",
+            InlineAbi::Event => "u32",
         }
     }
 
@@ -291,25 +293,11 @@ enum AttributeHandler<'name> {
     SetAttribute { name: &'name str },
     /// Use as a prop `el.name = value;`
     Prop { name: &'name str, attr: Attr },
-    /// Set as an event listener `el.addEventListener(name, value);`
-    Event {
-        name: &'name str,
-        event: &'static str,
-    },
     /// This is a link and needs its own special case
     Link,
 }
 
 fn attribute_handler(name: &str) -> AttributeHandler<'_> {
-    if name.starts_with("on") && name.len() > 2 {
-        let name = &name[2..];
-
-        return AttributeHandler::Event {
-            name,
-            event: event_js_type(name),
-        };
-    }
-
     match name {
         "link" => AttributeHandler::Link,
         "view_box" => AttributeHandler::SetAttribute { name: "viewBox" },

--- a/crates/kobold_macros/src/gener/element.rs
+++ b/crates/kobold_macros/src/gener/element.rs
@@ -120,6 +120,8 @@ impl IntoGenerator for HtmlElement {
                 value.stream
             };
 
+            gener.add_used_event(kind);
+
             let value = gener.add_field(coerce).event(event, el.typ).name;
 
             writeln!(el, "{var}[$_koboldSym[{}]]={value};", kind as usize);
@@ -146,6 +148,7 @@ impl IntoGenerator for HtmlElement {
                     AttributeHandler::Link => {
                         writeln!(el, "{var}.href={value};");
                         writeln!(el, "{var}[$_koboldSym[{}]]=0;", EventKind::Click as usize);
+                        gener.add_used_event(EventKind::Click);
                     }
                     AttributeHandler::Prop { name, .. } => {
                         writeln!(el, "{var}.{name}={value};");
@@ -173,6 +176,7 @@ impl IntoGenerator for HtmlElement {
 
                         writeln!(el, "{var}.href={value};");
                         writeln!(el, "{var}[$_koboldSym[{}]]=0;", EventKind::Click as usize);
+                        gener.add_used_event(EventKind::Click);
                     }
                     AttributeHandler::Prop { name, attr } => {
                         el.hoisted = true;

--- a/crates/kobold_macros/src/gener/element.rs
+++ b/crates/kobold_macros/src/gener/element.rs
@@ -172,7 +172,7 @@ impl IntoGenerator for HtmlElement {
                             .name;
 
                         writeln!(el, "{var}.href={value};");
-                        writeln!(el, "{var}.onclick=e=>wasmBindings.koboldLink(e);")
+                        writeln!(el, "{var}[$_koboldSym[{}]]=0;", EventKind::Click as usize);
                     }
                     AttributeHandler::Prop { name, attr } => {
                         el.hoisted = true;

--- a/crates/kobold_macros/src/gener/element.rs
+++ b/crates/kobold_macros/src/gener/element.rs
@@ -103,7 +103,8 @@ impl IntoGenerator for HtmlElement {
                     }
                     AttributeHandler::Link => {
                         writeln!(el, "{var}.href={value};");
-                        writeln!(el, "{var}.onclick=e=>wasmBindings.koboldLink(e);")
+                        writeln!(el, "{var}[$_koboldSym[0]]=0;")
+                        // writeln!(el, "{var}.onclick=e=>wasmBindings.koboldLink(e);")
                     }
                     AttributeHandler::Prop { name, .. } => {
                         writeln!(el, "{var}.{name}={value};");

--- a/crates/kobold_macros/src/gener/transient.rs
+++ b/crates/kobold_macros/src/gener/transient.rs
@@ -7,6 +7,7 @@ use std::fmt::{self, Debug, Display, Write};
 use arrayvec::ArrayString;
 use tokens::{Ident, Literal, TokenStream};
 
+use crate::event::EventKind;
 use crate::gener::Short;
 use crate::gener::element::{Attr, InlineAbi};
 use crate::itertools::IteratorExt;
@@ -20,6 +21,7 @@ pub type JsFnName = ArrayString<24>;
 pub struct Transient {
     pub js: JsModule,
     pub hints: Vec<Hint>,
+    pub events: Vec<EventKind>,
     pub fields: Vec<Field>,
     pub els: Vec<Short>,
 }
@@ -133,6 +135,17 @@ impl Tokenize for Transient {
         let mut product_generics = String::new();
         let mut product_generics_bounds = String::new();
 
+        let mut anchor_bounds = String::new();
+        let mut anchor_events = String::new();
+
+        for kind in self.events.iter() {
+            let _ = write!(
+                anchor_events,
+                ".used(::kobold::runtime::EventKind::{})",
+                kind.as_variant()
+            );
+        }
+
         for field in self.fields.iter() {
             let typ = field.make_type();
 
@@ -155,6 +168,11 @@ impl Tokenize for Transient {
 
             if let FieldKind::View { .. } | FieldKind::Event { .. } = field.kind {
                 let _ = write!(trigger_bounds, "{typ}: ::kobold::runtime::Trigger,");
+            }
+
+            if let FieldKind::View { .. } = field.kind {
+                let _ = write!(anchor_events, ".combine({typ}::EVENTS)");
+                let _ = write!(anchor_bounds, "{typ}: ::kobold::dom::Mountable,");
             }
         }
 
@@ -217,6 +235,7 @@ impl Tokenize for Transient {
                     \
                     impl<{product_generics}> ::kobold::dom::Anchor for TransientProduct<{product_generics}> \
                     where \
+                        {anchor_bounds}\
                         Self: 'static,\
                     ",
                 ),
@@ -226,7 +245,8 @@ impl Tokenize for Transient {
                 anchor_js_type,
                 ";",
                 format_args!("\
-                    const EVENTS: ::kobold::runtime::UsedEvents = ::kobold::runtime::UsedEvents::empty();\
+                    const EVENTS: ::kobold::runtime::UsedEvents = ::kobold::runtime::UsedEvents::empty()\
+                        {anchor_events};\
                     \
                     type Target = {anchor_type};\
                     \

--- a/crates/kobold_macros/src/gener/transient.rs
+++ b/crates/kobold_macros/src/gener/transient.rs
@@ -226,8 +226,10 @@ impl Tokenize for Transient {
                 anchor_js_type,
                 ";",
                 format_args!("\
-                    type Target = {anchor_type};
-
+                    const EVENTS: ::kobold::runtime::UsedEvents = ::kobold::runtime::UsedEvents::empty();\
+                    \
+                    type Target = {anchor_type};\
+                    \
                     fn anchor(&self) -> &Self::Target {{\
                         &self.e0\
                     }}\

--- a/crates/kobold_macros/src/gener/transient.rs
+++ b/crates/kobold_macros/src/gener/transient.rs
@@ -377,7 +377,7 @@ impl Display for JsArgument {
         match self.abi {
             Some(InlineAbi::Bool) => write!(f, "self.{name}.into()"),
             Some(InlineAbi::Str) => write!(f, "self.{name}.as_ref()"),
-            Some(InlineAbi::Event) => write!(f, "{name}.js_value()"),
+            Some(InlineAbi::Event) => write!(f, "{name}.event_key()"),
             None => write!(f, "{name}.js()"),
         }
     }

--- a/crates/kobold_macros/src/lib.rs
+++ b/crates/kobold_macros/src/lib.rs
@@ -17,6 +17,7 @@ use proc_macro::TokenStream;
 mod branching;
 mod class;
 mod dom;
+mod event;
 mod fn_component;
 mod gener;
 mod itertools;

--- a/crates/kobold_macros/src/syntax.rs
+++ b/crates/kobold_macros/src/syntax.rs
@@ -5,6 +5,7 @@
 //! `Parse` logic for different syntax elements
 
 use std::fmt::{self, Display, Write};
+use std::ops::{Deref, DerefMut};
 
 use tokens::{Ident, Literal, TokenStream};
 
@@ -60,20 +61,34 @@ impl Tokenize for Generics {
 
 /// CSS-style label, matches sequences of identifiers with dashes allowed.
 #[derive(Debug)]
-pub struct CssLabel {
+pub struct Label {
     /// Complete label with dashes
     pub label: String,
     /// Last ident in label
     pub ident: Ident,
 }
 
-impl Display for CssLabel {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.label)
+impl Deref for Label {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.label
     }
 }
 
-impl Parse for CssLabel {
+impl DerefMut for Label {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.label
+    }
+}
+
+impl Display for Label {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self)
+    }
+}
+
+impl Parse for Label {
     fn parse(stream: &mut ParseStream) -> Result<Self, ParseError> {
         let mut ident: Ident = stream.parse()?;
         let mut label = String::new();
@@ -88,13 +103,13 @@ impl Parse for CssLabel {
             write!(&mut label, "-{ident}").unwrap();
         }
 
-        Ok(CssLabel { label, ident })
+        Ok(Label { label, ident })
     }
 }
 
-impl CssLabel {
+impl Label {
     pub fn into_literal(self) -> Literal {
-        let mut lit = string(&self.label);
+        let mut lit = string(&self);
 
         // Keep resolution to literal, but change location
         lit.set_span(lit.span().located_at(self.ident.span()));

--- a/crates/kobold_macros/src/syntax.rs
+++ b/crates/kobold_macros/src/syntax.rs
@@ -93,8 +93,6 @@ impl Parse for Label {
         let mut ident: Ident = stream.parse()?;
         let mut label = String::new();
 
-        // let span = ident.span();
-
         write!(&mut label, "{ident}").unwrap();
 
         while stream.allow_consume('-').is_some() {

--- a/crates/kobold_qr/Cargo.toml
+++ b/crates/kobold_qr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kobold_qr"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Maciej Hirsz <hello@maciej.codes>"]
 edition = "2024"
 rust-version = "1.85"

--- a/crates/kobold_qr/src/lib.rs
+++ b/crates/kobold_qr/src/lib.rs
@@ -6,8 +6,8 @@ use std::fmt::Write;
 use fast_qr::Module;
 use fast_qr::qr::QRBuilder;
 
-use kobold::prelude::*;
 use kobold::diff::fence;
+use kobold::prelude::*;
 
 /// Error Correction Coding has 4 levels
 pub enum Ecl {


### PR DESCRIPTION
Will make a proper description once I merge the router back to dev, but this essentially handles all events on application root (currently always `document.body`) instead of attaching listeners on each element. This adds a bit of code, particularly the util.js is a bit larger now, however the produced Wasm code is going to be slightly smaller and fresh render of new events should be faster and use less memory on the JS/DOM side.